### PR TITLE
ci: ensure PR title follows conventional commits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    uses: folke/github/.github/workflows/pr.yml@main
+    secrets: inherit


### PR DESCRIPTION
- **refactor: `git blame --line-porcelain` for machine readability**
- **ci: ensure PR title follows conventional commits**
