### PR TITLE
feat(navigation): move cursor to commit_info.source_line

### DIFF
--- a/lua/blame/blame_view.lua
+++ b/lua/blame/blame_view.lua
@@ -175,10 +175,11 @@ function BlameView:update_view(commit_info)
 
 	vim.api.nvim_set_option_value("modifiable", false, { scope = "local", buf = self.blame_popup_instance.bufnr })
 	vim.api.nvim_set_option_value("modifiable", false, { scope = "local", buf = self.file_popup_instance.bufnr })
-end
 
-function BlameView:update_buffers(commit_info)
-	self:update_view(commit_info)
+	if commit_info and commit_info.header and commit_info.header.source_line then
+		utils.set_cursor_to_line(self.blame_popup_instance.winid, commit_info.header.source_line)
+		utils.set_cursor_to_line(self.file_popup_instance.winid, commit_info.header.source_line)
+	end
 end
 
 function BlameView:navigate_forward()
@@ -194,8 +195,7 @@ function BlameView:navigate_forward()
 	end
 
 	if self.breadcrumb:push(commit_info) then
-		local current = self.breadcrumb:current()
-		self:update_buffers(current)
+		self:update_view(self.breadcrumb:current())
 	end
 end
 
@@ -205,8 +205,7 @@ function BlameView:navigate_backward()
 		return
 	end
 	self.breadcrumb:pop()
-	local current = self.breadcrumb:current()
-	self:update_buffers(current)
+	self:update_view(self.breadcrumb:current())
 end
 
 function BlameView:close()

--- a/lua/blame/init.lua
+++ b/lua/blame/init.lua
@@ -39,7 +39,7 @@ function M.show_blame_info()
 	if not blame_view then
 		return
 	end
-	blame_view:update_buffers(nil)
+	blame_view:update_view(nil)
 
 	-- Mount the layout
 	blame_view:mount()

--- a/lua/blame/utils.lua
+++ b/lua/blame/utils.lua
@@ -29,6 +29,24 @@ function M.initialize_cursor_position(original_win, win)
 	vim.api.nvim_set_option_value("cursorbind", true, { scope = "local", win = win })
 end
 
+--- Sets the cursor position in a window to a specific line.
+--- @param win number The handle of the window.
+--- @param line_num number The line number to set the cursor to.
+function M.set_cursor_to_line(win, line_num)
+	if not win or not vim.api.nvim_win_is_valid(win) then
+		return
+	end
+	local buf = vim.api.nvim_win_get_buf(win)
+	local line_count = vim.api.nvim_buf_line_count(buf)
+	if line_num > line_count then
+		line_num = line_count
+	end
+	if line_num < 1 then
+		line_num = 1
+	end
+	vim.api.nvim_win_set_cursor(win, { line_num, 0 })
+end
+
 --- Adds a keymap for one or many keys to a popup.
 --- @param popup table The nui.popup instance.
 --- @param keys string|table The key or list of keys to map.

--- a/tests/blame/blame_view_spec.lua
+++ b/tests/blame/blame_view_spec.lua
@@ -166,4 +166,101 @@ describe("blame.blame_view", function()
 		blame_view:close()
 		vim.api.nvim_buf_delete(buf_id, { force = true })
 	end)
+
+	it("sets cursor to source_line when navigating forward", function()
+		local buf_id = vim.api.nvim_create_buf(false, true)
+		local mock_git = {
+			original_file = "/path/to/repo/file.lua",
+			git_root = "/path/to/repo",
+			get_blame_output = function()
+				local lines = {}
+				for i = 1, 50 do
+					table.insert(lines, string.format("abcdef1234567890 %d %d 1", i, i))
+					table.insert(lines, "author Test")
+					table.insert(lines, "author-time 123456789")
+					table.insert(lines, "filename file.lua")
+					table.insert(lines, "\tline content " .. i)
+				end
+				return table.concat(lines, "\n")
+			end,
+		}
+
+		local blame_view = BlameView:new({
+			git_instance = mock_git,
+		})
+
+		blame_view:update_view(nil)
+		blame_view:mount()
+
+		-- Setup some blame lines with source_line
+		blame_view.blame_lines = {
+			{
+				header = { commit = "hash1", source_line = 42, result_line = 1 },
+				previous = { commit = "prev_hash", filename = "file.lua" },
+				author = "Test",
+				date = "2026-02-24",
+			},
+		}
+
+		-- Mock current cursor position in blame popup (line 1)
+		vim.api.nvim_win_set_cursor(blame_view.blame_popup_instance.winid, { 1, 0 })
+
+		-- Execute navigate_forward
+		blame_view:navigate_forward()
+
+		-- Verify actual cursor position
+		assert.are.same({ 42, 0 }, vim.api.nvim_win_get_cursor(blame_view.blame_popup_instance.winid))
+		assert.are.same({ 42, 0 }, vim.api.nvim_win_get_cursor(blame_view.file_popup_instance.winid))
+
+		blame_view:close()
+		vim.api.nvim_buf_delete(buf_id, { force = true })
+	end)
+
+	it("sets cursor to source_line when navigating backward", function()
+		local buf_id = vim.api.nvim_create_buf(false, true)
+		local mock_git = {
+			original_file = "/path/to/repo/file.lua",
+			git_root = "/path/to/repo",
+			get_blame_output = function()
+				local lines = {}
+				for i = 1, 50 do
+					table.insert(lines, string.format("abcdef1234567890 %d %d 1", i, i))
+					table.insert(lines, "author Test")
+					table.insert(lines, "author-time 123456789")
+					table.insert(lines, "filename file.lua")
+					table.insert(lines, "\tline content " .. i)
+				end
+				return table.concat(lines, "\n")
+			end,
+		}
+
+		local blame_view = BlameView:new({
+			git_instance = mock_git,
+		})
+
+		blame_view:update_view(nil)
+		blame_view:mount()
+
+		-- Setup breadcrumb with two items
+		local item1 = {
+			header = { commit = "hash1", source_line = 10, result_line = 1 },
+			previous = { commit = "prev1", filename = "file.lua" },
+		}
+		local item2 = {
+			header = { commit = "hash2", source_line = 20, result_line = 1 },
+			previous = { commit = "prev2", filename = "file.lua" },
+		}
+		blame_view.breadcrumb:push(item1)
+		blame_view.breadcrumb:push(item2)
+
+		-- Execute navigate_backward (pops item2, current becomes item1)
+		blame_view:navigate_backward()
+
+		-- Verify actual cursor position
+		assert.are.same({ 10, 0 }, vim.api.nvim_win_get_cursor(blame_view.blame_popup_instance.winid))
+		assert.are.same({ 10, 0 }, vim.api.nvim_win_get_cursor(blame_view.file_popup_instance.winid))
+
+		blame_view:close()
+		vim.api.nvim_buf_delete(buf_id, { force = true })
+	end)
 end)

--- a/tests/blame/utils_spec.lua
+++ b/tests/blame/utils_spec.lua
@@ -137,4 +137,20 @@ describe("blame.utils: integrates with real Neovim windows", function()
 		local blame_cursor_pos = vim.api.nvim_win_get_cursor(blame_win_id)
 		assert.are.same({ blame_line_count, 0 }, blame_cursor_pos)
 	end)
+
+	it("sets cursor to a specific line using set_cursor_to_line", function()
+		utils.set_cursor_to_line(blame_win_id, 5)
+		local cursor_pos = vim.api.nvim_win_get_cursor(blame_win_id)
+		assert.are.same({ 5, 0 }, cursor_pos)
+
+		-- Test upper bound
+		utils.set_cursor_to_line(blame_win_id, 100)
+		cursor_pos = vim.api.nvim_win_get_cursor(blame_win_id)
+		assert.are.same({ 15, 0 }, cursor_pos) -- 15 is the line count in before_each
+
+		-- Test lower bound
+		utils.set_cursor_to_line(blame_win_id, 0)
+		cursor_pos = vim.api.nvim_win_get_cursor(blame_win_id)
+		assert.are.same({ 1, 0 }, cursor_pos)
+	end)
 end)


### PR DESCRIPTION
This will make use of the `source_line` given by `git blame`. It will
navigate back to the `source_line` which is not necessarily the
previous cursor position. This should be improved by adding entries
to the jumplist probably.
