### PR TITLE
feat(navigation): restore old cursor position

### DIFF
--- a/lua/blame/blame_view.lua
+++ b/lua/blame/blame_view.lua
@@ -74,12 +74,17 @@ end
 
 function BlameView:mount()
 	local current_file_win = vim.api.nvim_get_current_win()
+	local cursor_pos = vim.api.nvim_win_get_cursor(current_file_win)
+	self.breadcrumb:push({ commit_info = nil, cursor_pos = cursor_pos })
+
 	self.layout:mount()
 
 	-- Set current window to the blame popup for initial blame display
 	if self.blame_popup_instance and self.blame_popup_instance.winid then
 		vim.api.nvim_set_current_win(self.blame_popup_instance.winid)
 	end
+
+	self:update_view(nil)
 
 	utils.initialize_cursor_position(current_file_win, self.blame_popup_instance.winid)
 	utils.initialize_cursor_position(current_file_win, self.file_popup_instance.winid)
@@ -175,11 +180,6 @@ function BlameView:update_view(commit_info)
 
 	vim.api.nvim_set_option_value("modifiable", false, { scope = "local", buf = self.blame_popup_instance.bufnr })
 	vim.api.nvim_set_option_value("modifiable", false, { scope = "local", buf = self.file_popup_instance.bufnr })
-
-	if commit_info and commit_info.header and commit_info.header.source_line then
-		utils.set_cursor_to_line(self.blame_popup_instance.winid, commit_info.header.source_line)
-		utils.set_cursor_to_line(self.file_popup_instance.winid, commit_info.header.source_line)
-	end
 end
 
 function BlameView:navigate_forward()
@@ -194,18 +194,33 @@ function BlameView:navigate_forward()
 		return
 	end
 
-	if self.breadcrumb:push(commit_info) then
-		self:update_view(self.breadcrumb:current())
+	local current = self.breadcrumb:current()
+	if current then
+		current.cursor_pos = vim.api.nvim_win_get_cursor(0)
+	end
+
+	if self.breadcrumb:push({ commit_info = commit_info, cursor_pos = nil }) then
+		self:update_view(commit_info)
+		if commit_info and commit_info.header and commit_info.header.source_line then
+			utils.set_cursor_to_line(self.blame_popup_instance.winid, commit_info.header.source_line)
+			utils.set_cursor_to_line(self.file_popup_instance.winid, commit_info.header.source_line)
+		end
 	end
 end
 
 function BlameView:navigate_backward()
-	if #self.breadcrumb.stack == 0 then
+	if #self.breadcrumb.stack <= 1 then
 		vim.notify("blame.nvim: No more history to go back to.", vim.log.levels.INFO)
 		return
 	end
 	self.breadcrumb:pop()
-	self:update_view(self.breadcrumb:current())
+	local current = self.breadcrumb:current()
+	self:update_view(current.commit_info)
+
+	if current.cursor_pos then
+		vim.api.nvim_win_set_cursor(self.blame_popup_instance.winid, current.cursor_pos)
+		vim.api.nvim_win_set_cursor(self.file_popup_instance.winid, current.cursor_pos)
+	end
 end
 
 function BlameView:close()

--- a/lua/blame/breadcrumb.lua
+++ b/lua/blame/breadcrumb.lua
@@ -1,8 +1,15 @@
 -- lua/blame/breadcrumb.lua
 
+---@class BreadcrumbItem
+---@field commit_info Porcelain|nil
+---@field cursor_pos number[]|nil
+
+---@class Breadcrumb
+---@field stack BreadcrumbItem[]
 local Breadcrumb = {}
 Breadcrumb.__index = Breadcrumb
 
+---@return Breadcrumb
 function Breadcrumb:new()
 	local instance = {
 		stack = {}, -- Stack will store all visited items, including the current one
@@ -11,24 +18,33 @@ function Breadcrumb:new()
 	return instance
 end
 
+---@return BreadcrumbItem|nil
 function Breadcrumb:current()
 	return self.stack[#self.stack] -- The last item on the stack is the current one
 end
 
+---@param new_item BreadcrumbItem
+---@return boolean
 function Breadcrumb:push(new_item)
 	-- Do not add the special revision "00000000" to the stack
-	if new_item.header.commit:match("^00000000") then
+	if new_item.commit_info and new_item.commit_info.header.commit:match("^00000000") then
 		return false -- not added
 	end
 	-- Check if the new_item is the same as the current item
 	local current = self:current()
-	if current and new_item.header.commit == current.header.commit then
+	if
+		current
+		and new_item.commit_info
+		and current.commit_info
+		and new_item.commit_info.header.commit == current.commit_info.header.commit
+	then
 		return false -- not added
 	end
 	table.insert(self.stack, new_item) -- Add the new item to the stack
 	return true -- added
 end
 
+---@return BreadcrumbItem|nil
 function Breadcrumb:pop()
 	return table.remove(self.stack) -- The item that *was* current
 end

--- a/lua/blame/init.lua
+++ b/lua/blame/init.lua
@@ -39,7 +39,6 @@ function M.show_blame_info()
 	if not blame_view then
 		return
 	end
-	blame_view:update_view(nil)
 
 	-- Mount the layout
 	blame_view:mount()

--- a/tests/blame/blame_view_spec.lua
+++ b/tests/blame/blame_view_spec.lua
@@ -41,7 +41,11 @@ describe("blame.blame_view", function()
 		local mock_git = {
 			original_file = "/path/to/repo/file.lua",
 			git_root = "/path/to/repo",
-			get_blame_output = stub({}, "get_blame_output", "abcdef1234567890 1 1 1\nauthor Test\nauthor-time 123456789\nfilename file.lua\n\tline content 1\nabcdef1234567890 2 2\n\tline content 2\n"),
+			get_blame_output = stub(
+				{},
+				"get_blame_output",
+				"abcdef1234567890 1 1 1\nauthor Test\nauthor-time 123456789\nfilename file.lua\n\tline content 1\nabcdef1234567890 2 2\n\tline content 2\n"
+			),
 		}
 
 		local blame_view = BlameView:new({
@@ -80,7 +84,11 @@ describe("blame.blame_view", function()
 		local mock_git = {
 			original_file = "/path/to/repo/file.lua",
 			git_root = "/path/to/repo",
-			get_blame_output = stub({}, "get_blame_output", "abcdef1234567890 1 1 1\nauthor Test\nauthor-time 123456789\nfilename file.lua\n\tline content 1\n"),
+			get_blame_output = stub(
+				{},
+				"get_blame_output",
+				"abcdef1234567890 1 1 1\nauthor Test\nauthor-time 123456789\nfilename file.lua\n\tline content 1\n"
+			),
 		}
 
 		local blame_view = BlameView:new({
@@ -88,8 +96,20 @@ describe("blame.blame_view", function()
 		})
 
 		-- Pre-fill buffers with more lines
-		vim.api.nvim_buf_set_lines(blame_view.blame_popup_instance.bufnr, 0, -1, false, { "old line 1", "old line 2", "old line 3" })
-		vim.api.nvim_buf_set_lines(blame_view.file_popup_instance.bufnr, 0, -1, false, { "old line 1", "old line 2", "old line 3" })
+		vim.api.nvim_buf_set_lines(
+			blame_view.blame_popup_instance.bufnr,
+			0,
+			-1,
+			false,
+			{ "old line 1", "old line 2", "old line 3" }
+		)
+		vim.api.nvim_buf_set_lines(
+			blame_view.file_popup_instance.bufnr,
+			0,
+			-1,
+			false,
+			{ "old line 1", "old line 2", "old line 3" }
+		)
 
 		blame_view:update_view(nil)
 
@@ -105,7 +125,11 @@ describe("blame.blame_view", function()
 
 	it("mounts the layout and initializes positions", function()
 		local buf_id = vim.api.nvim_create_buf(false, true)
-		local mock_git = {}
+		local mock_git = {
+			original_file = "/path/to/repo/file.lua",
+			git_root = "/path/to/repo",
+			get_blame_output = stub({}, "get_blame_output", ""),
+		}
 		local blame_view = BlameView:new({ git_instance = mock_git })
 
 		local blame_view_layout_mount_spy = spy.on(blame_view.layout, "mount")
@@ -116,6 +140,8 @@ describe("blame.blame_view", function()
 
 		assert.spy(blame_view_layout_mount_spy).was.called(1)
 		assert.spy(utils_initialize_cursor_position_spy).was.called(2)
+		assert.are.equal(1, #blame_view.breadcrumb.stack)
+		assert.is_nil(blame_view.breadcrumb:current().commit_info)
 
 		vim.api.nvim_buf_delete(buf_id, { force = true })
 	end)
@@ -147,7 +173,6 @@ describe("blame.blame_view", function()
 			git_instance = mock_git,
 		})
 
-		blame_view:update_view(nil)
 		blame_view:mount()
 
 		local blame_win = blame_view.blame_popup_instance.winid
@@ -189,7 +214,6 @@ describe("blame.blame_view", function()
 			git_instance = mock_git,
 		})
 
-		blame_view:update_view(nil)
 		blame_view:mount()
 
 		-- Setup some blame lines with source_line
@@ -216,7 +240,7 @@ describe("blame.blame_view", function()
 		vim.api.nvim_buf_delete(buf_id, { force = true })
 	end)
 
-	it("sets cursor to source_line when navigating backward", function()
+	it("restores cursor position when navigating backward", function()
 		local buf_id = vim.api.nvim_create_buf(false, true)
 		local mock_git = {
 			original_file = "/path/to/repo/file.lua",
@@ -238,27 +262,30 @@ describe("blame.blame_view", function()
 			git_instance = mock_git,
 		})
 
-		blame_view:update_view(nil)
 		blame_view:mount()
 
 		-- Setup breadcrumb with two items
 		local item1 = {
-			header = { commit = "hash1", source_line = 10, result_line = 1 },
-			previous = { commit = "prev1", filename = "file.lua" },
+			commit_info = {
+				header = { commit = "hash1", source_line = 10, result_line = 1 },
+				previous = { commit = "prev1", filename = "file.lua" },
+			},
+			cursor_pos = { 15, 0 }, -- This is what we want to restore to
 		}
 		local item2 = {
-			header = { commit = "hash2", source_line = 20, result_line = 1 },
-			previous = { commit = "prev2", filename = "file.lua" },
+			commit_info = {
+				header = { commit = "hash2", source_line = 20, result_line = 1 },
+				previous = { commit = "prev2", filename = "file.lua" },
+			},
 		}
-		blame_view.breadcrumb:push(item1)
-		blame_view.breadcrumb:push(item2)
+		blame_view.breadcrumb.stack = { item1, item2 }
 
 		-- Execute navigate_backward (pops item2, current becomes item1)
 		blame_view:navigate_backward()
 
-		-- Verify actual cursor position
-		assert.are.same({ 10, 0 }, vim.api.nvim_win_get_cursor(blame_view.blame_popup_instance.winid))
-		assert.are.same({ 10, 0 }, vim.api.nvim_win_get_cursor(blame_view.file_popup_instance.winid))
+		-- Verify actual cursor position is restored from item1.cursor_pos, NOT from source_line
+		assert.are.same({ 15, 0 }, vim.api.nvim_win_get_cursor(blame_view.blame_popup_instance.winid))
+		assert.are.same({ 15, 0 }, vim.api.nvim_win_get_cursor(blame_view.file_popup_instance.winid))
 
 		blame_view:close()
 		vim.api.nvim_buf_delete(buf_id, { force = true })

--- a/tests/blame/breadcrumb_spec.lua
+++ b/tests/blame/breadcrumb_spec.lua
@@ -11,7 +11,7 @@ describe("blame.breadcrumb", function()
 
 	it("pushes a new item", function()
 		local bc = Breadcrumb:new()
-		local item = { header = { commit = "hash1" } }
+		local item = { commit_info = { header = { commit = "hash1" } }, cursor_pos = { 1, 0 } }
 		local added = bc:push(item)
 		assert.is_true(added)
 		assert.are.same({ item }, bc.stack)
@@ -20,7 +20,7 @@ describe("blame.breadcrumb", function()
 
 	it("does not push a duplicate item", function()
 		local bc = Breadcrumb:new()
-		local item = { header = { commit = "hash1" } }
+		local item = { commit_info = { header = { commit = "hash1" } }, cursor_pos = { 1, 0 } }
 		bc:push(item)
 		local added = bc:push(item)
 		assert.is_false(added)
@@ -30,8 +30,8 @@ describe("blame.breadcrumb", function()
 
 	it("pushes multiple items", function()
 		local bc = Breadcrumb:new()
-		local item1 = { header = { commit = "hash1" } }
-		local item2 = { header = { commit = "hash2" } }
+		local item1 = { commit_info = { header = { commit = "hash1" } }, cursor_pos = { 1, 0 } }
+		local item2 = { commit_info = { header = { commit = "hash2" } }, cursor_pos = { 2, 0 } }
 		bc:push(item1)
 		bc:push(item2)
 		assert.are.same({ item1, item2 }, bc.stack)
@@ -40,8 +40,8 @@ describe("blame.breadcrumb", function()
 
 	it("pops an item", function()
 		local bc = Breadcrumb:new()
-		local item1 = { header = { commit = "hash1" } }
-		local item2 = { header = { commit = "hash2" } }
+		local item1 = { commit_info = { header = { commit = "hash1" } }, cursor_pos = { 1, 0 } }
+		local item2 = { commit_info = { header = { commit = "hash2" } }, cursor_pos = { 2, 0 } }
 		bc:push(item1)
 		bc:push(item2)
 		local popped_item = bc:pop()
@@ -60,7 +60,10 @@ describe("blame.breadcrumb", function()
 
 	it("does not push '00000000' to the stack", function()
 		local bc = Breadcrumb:new()
-		local item = { header = { commit = "0000000000000000000000000000000000000000" } }
+		local item = {
+			commit_info = { header = { commit = "0000000000000000000000000000000000000000" } },
+			cursor_pos = { 1, 0 },
+		}
 		local added = bc:push(item)
 		assert.is_false(added)
 		assert.are.same({}, bc.stack)


### PR DESCRIPTION
Unfortunately, this re-invents the wheel a little. I'm implementing
jumpmarks here.

I'm thinking about shipping a custom language server for filetype
`git_blame` and navigating with `go to definition` etc. and updating the
file window with auto commands.
